### PR TITLE
Declare minimum PHP required version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,6 +9,9 @@
     "email verification",
     "disposable email check"
   ],
+  "require": {
+    "php": "^7.0"
+  },
   "require-dev": {
     "mockery/mockery": "^0.9.9",
     "phpunit/phpunit": "^6.2"


### PR DESCRIPTION
Tiny declaration for composer to not allow package installation on PHP lower than 7.0.