### PR TITLE
README.md - Fixed typo on array result

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ require __DIR__ . '/vendor/autoload.php';
 $validator = EmailValidation\EmailValidatorFactory::create('dave@gmoil.con');
 
 $jsonResult = $validator->getValidationResults()->asJson();
-$arrayResult = $validator->getValidationResults()->asAray();
+$arrayResult = $validator->getValidationResults()->asArray();
 
 echo $jsonResult;
 


### PR DESCRIPTION
There was a typo for the function for the array result, corrected this.