### PR TITLE
travis: extended checks to php 7.2 and 7.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ language: php
 php:
   - 7.0
   - 7.1
+  - 7.2
+  - 7.3
 
 before_script:
     - travis_retry composer self-update


### PR DESCRIPTION
PHP 7.2 and 7.3 were not included in Travis run.