### PR TITLE
Add eml.cc domain

### DIFF
--- a/src/data/email-providers.php
+++ b/src/data/email-providers.php
@@ -626,6 +626,7 @@ return [
     'emailx.net',
     'ematic.com',
     'embarqmail.com',
+    'eml.cc',
     'emumail.com',
     'end-war.com',
     'enel.net',


### PR DESCRIPTION
Add eml.cc domain to the providers. This domain is alias for fastmail.com