### PR TITLE
Check for domain with www in host validator

### DIFF
--- a/src/Validations/EmailHostValidator.php
+++ b/src/Validations/EmailHostValidator.php
@@ -15,7 +15,7 @@ class EmailHostValidator extends Validator implements ValidatorInterface
     {
         $hostName = $this->getEmailAddress()->getHostPart();
         if ($hostName) {
-            return ($this->getHostByName($hostName) !== $hostName);
+            return ($this->getHostByName($hostName) !== $hostName) || ($this->getHostByName('www.' . $hostName) !== $hostName);
         }
 
         return false; // @codeCoverageIgnore


### PR DESCRIPTION
Sometimes the host domain with `www.` could be validated but we miss this in the validator and mark the host as invalid. We should also check these kind of hosts.